### PR TITLE
fix: Add email-validator to requirements for Pydantic

### DIFF
--- a/job_scraping_app/requirements.txt
+++ b/job_scraping_app/requirements.txt
@@ -10,6 +10,6 @@ python-docx
 sqlalchemy
 psycopg2-binary
 alembic
-pydantic[dotenv] # For BaseSettings .env file loading
+pydantic[dotenv,email] # For BaseSettings .env file loading and email validation
 streamlit
 gunicorn


### PR DESCRIPTION
Ensures that pydantic[email] is installed, which provides the email-validator package needed for EmailStr validation. This resolves a ModuleNotFoundError when running database migrations or other operations that initialize Pydantic models with EmailStr fields.