### PR TITLE
fix: Ensure postgresql:// scheme in alembic/env.py

### DIFF
--- a/job_scraping_app/alembic/env.py
+++ b/job_scraping_app/alembic/env.py
@@ -88,7 +88,12 @@ def run_migrations_online():
     engine_config = config.get_section(config.config_ini_section)
     if engine_config is None: # Should not happen with default alembic.ini structure
         engine_config = {}
-    engine_config['sqlalchemy.url'] = settings.DATABASE_URL
+    
+    # Ensure the DATABASE_URL uses the 'postgresql://' scheme
+    db_url = settings.DATABASE_URL
+    if db_url and db_url.startswith("postgres://"):
+        db_url = db_url.replace("postgres://", "postgresql://", 1)
+    engine_config['sqlalchemy.url'] = db_url
     
     connectable = engine_from_config(
         engine_config, # Use the modified config section


### PR DESCRIPTION
I modified alembic/env.py to explicitly convert DATABASE_URL starting with 'postgres://' to 'postgresql://' before passing it to SQLAlchemy's engine_from_config. This aims to resolve potential dialect loading issues on Heroku.