### PR TITLE
Okay, I've made a change to ensure the postgresql:// scheme is used i…

### DIFF
--- a/job_scraping_app/app/db/session.py
+++ b/job_scraping_app/app/db/session.py
@@ -6,7 +6,12 @@ from app.core.config import settings
 if not settings.DATABASE_URL:
     raise ValueError("DATABASE_URL not set in settings. Make sure your .env file is configured correctly.")
 
-engine = create_engine(settings.DATABASE_URL, pool_pre_ping=True)
+# Ensure the DATABASE_URL uses the 'postgresql://' scheme
+db_url = settings.DATABASE_URL
+if db_url and db_url.startswith("postgres://"):
+    db_url = db_url.replace("postgres://", "postgresql://", 1)
+
+engine = create_engine(db_url, pool_pre_ping=True) # Preserved pool_pre_ping
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 def get_db():


### PR DESCRIPTION
…n app/db/session.py.

I modified app/db/session.py to explicitly convert DATABASE_URL starting with 'postgres://' to 'postgresql://' before it's used by SQLAlchemy.

This is similar to a previous adjustment and should help resolve a 'NoSuchModuleError' you might have been seeing.