### PR TITLE
fix: Add python-multipart to requirements

### DIFF
--- a/job_scraping_app/requirements.txt
+++ b/job_scraping_app/requirements.txt
@@ -14,3 +14,4 @@ pydantic[dotenv,email] # For BaseSettings .env file loading and email validation
 streamlit
 gunicorn
 pydantic-settings
+python-multipart


### PR DESCRIPTION
This package is required by FastAPI for handling form data and file uploads. Its absence was causing a RuntimeError on Heroku during application startup, leading to an R10 boot timeout.